### PR TITLE
Add Copy DRS URI to resource Access dropdown

### DIFF
--- a/ckanext/bpatheme/assets/scripts/drs_copy_uri.js
+++ b/ckanext/bpatheme/assets/scripts/drs_copy_uri.js
@@ -15,7 +15,7 @@ ckan.module('drs_copy_uri', function ($) {
             }
             var self = this;
             navigator.clipboard.writeText(uri).then(
-                function () { self._toggleFeedback(uri); },
+                function () { self._toggleFeedback('DRS URI copied to clipboard'); },
                 function (err) { self._toggleFeedback('ERROR: ' + err); }
             );
         },

--- a/ckanext/bpatheme/assets/scripts/drs_copy_uri.js
+++ b/ckanext/bpatheme/assets/scripts/drs_copy_uri.js
@@ -1,0 +1,42 @@
+'use strict';
+
+ckan.module('drs_copy_uri', function ($) {
+    return {
+        initialize: function () {
+            $.proxyAll(this, /_on/);
+            this.el.on('click', this._onClick);
+        },
+        _onClick: function (event) {
+            event.preventDefault();
+            var uri = this.options.uri;
+            if (!uri) {
+                this._toggleFeedback('No DRS URI available');
+                return;
+            }
+            var self = this;
+            navigator.clipboard.writeText(uri).then(
+                function () { self._toggleFeedback(uri); },
+                function (err) { self._toggleFeedback('ERROR: ' + err); }
+            );
+        },
+        _toggleFeedback: function (message) {
+            var element = $(this.el[0]).closest('div');
+            $(element).on('shown.bs.popover', function () {
+                $('.popover').one('click', function () {
+                    $(this).closest('div').popover('destroy');
+                });
+                setTimeout(function () {
+                    element.popover('destroy');
+                }, 6000);
+            });
+            element.popover('destroy');
+            element.popover({
+                title: 'Copied to clipboard!',
+                html: true,
+                content: message,
+                placement: 'left'
+            });
+            element.popover('show');
+        }
+    };
+});

--- a/ckanext/bpatheme/assets/scripts/drs_copy_uri.js
+++ b/ckanext/bpatheme/assets/scripts/drs_copy_uri.js
@@ -15,7 +15,7 @@ ckan.module('drs_copy_uri', function ($) {
             }
             var self = this;
             navigator.clipboard.writeText(uri).then(
-                function () { self._toggleFeedback('DRS URI copied to clipboard'); },
+                function () { self._toggleFeedback('DRS URL copied to clipboard'); },
                 function (err) { self._toggleFeedback('ERROR: ' + err); }
             );
         },

--- a/ckanext/bpatheme/assets/webassets.yml
+++ b/ckanext/bpatheme/assets/webassets.yml
@@ -43,3 +43,12 @@ bootstraptable-css:
   output: ckanext-bpatheme/%(version)s_bootstraptable.css
   contents:
      - bootstraptable/bootstrap-table.min.css
+
+drs-copy-js:
+  filters: rjsmin
+  extra:
+    preload:
+      - base/main
+  output: ckanext-bpatheme/%(version)s_drs_copy.js
+  contents:
+    - scripts/drs_copy_uri.js

--- a/ckanext/bpatheme/helper.py
+++ b/ckanext/bpatheme/helper.py
@@ -28,8 +28,8 @@ def get_current_year():
 
 
 def get_drs_uri(id):
-    site_url = config.get("ckan.site_url", "").rstrip("/")
-    return f"{site_url}/ga4gh/drs/v1/objects/{id}"
+    hostname = urlparse(config.get("ckan.site_url", "")).hostname or ""
+    return f"drs://{hostname}/{id}"
 
 
 def wa_license_icon(id):

--- a/ckanext/bpatheme/helper.py
+++ b/ckanext/bpatheme/helper.py
@@ -28,8 +28,8 @@ def get_current_year():
 
 
 def get_drs_uri(id):
-    hostname = urlparse(config.get("ckan.site_url", "")).hostname or ""
-    return f"drs://{hostname}/{id}"
+    site_url = config.get("ckan.site_url", "").rstrip("/")
+    return f"{site_url}/ga4gh/drs/v1/objects/{id}"
 
 
 def wa_license_icon(id):

--- a/ckanext/bpatheme/helper.py
+++ b/ckanext/bpatheme/helper.py
@@ -27,6 +27,11 @@ def get_current_year():
     return datetime.datetime.today().year
 
 
+def get_drs_uri(id):
+    hostname = urlparse(config.get("ckan.site_url", "")).hostname or ""
+    return f"drs://{hostname}/{id}"
+
+
 def wa_license_icon(id):
     icons = {
         "cc-by": ["cc", "cc-by"],

--- a/ckanext/bpatheme/plugins.py
+++ b/ckanext/bpatheme/plugins.py
@@ -143,6 +143,7 @@ class CustomTheme(plugins.SingletonPlugin):
             "check_user_dataset_access":helper.check_user_dataset_access,
             "is_bioproject": helper.is_bioproject,
             "render_ncbi_bioproject_url": helper.render_ncbi_bioproject_url,
+            "get_drs_uri": helper.get_drs_uri,
         }
 
     # Ifacets

--- a/ckanext/bpatheme/templates/ajax_snippets/shopping_cart_dock_not_empty.html
+++ b/ckanext/bpatheme/templates/ajax_snippets/shopping_cart_dock_not_empty.html
@@ -23,17 +23,6 @@
                 >
                         {{ _("Remove") }}
                 </button>
-                {% if item.details.id %}
-                <div style="display:inline-block;">
-                    {% asset 'ckanext-bpatheme/drs-copy-js' %}
-                    <a href="#"
-                       class="btn btn-sm btn-default drs_copy_uri"
-                       data-module="drs_copy_uri"
-                       data-module-uri="{{ h.get_drs_uri(item.details.id) }}">
-                        <i class="fa fa-copy"></i> {{ _('Copy DRS Bundle URI') }}
-                    </a>
-                </div>
-                {% endif %}
             </div>
         </li>
        {% else %}

--- a/ckanext/bpatheme/templates/ajax_snippets/shopping_cart_dock_not_empty.html
+++ b/ckanext/bpatheme/templates/ajax_snippets/shopping_cart_dock_not_empty.html
@@ -23,6 +23,17 @@
                 >
                         {{ _("Remove") }}
                 </button>
+                {% if item.details.id %}
+                <div style="display:inline-block;">
+                    {% asset 'ckanext-bpatheme/drs-copy-js' %}
+                    <a href="#"
+                       class="btn btn-sm btn-default drs_copy_uri"
+                       data-module="drs_copy_uri"
+                       data-module-uri="{{ h.get_drs_uri(item.details.id) }}">
+                        <i class="fa fa-copy"></i> {{ _('Copy DRS Bundle URI') }}
+                    </a>
+                </div>
+                {% endif %}
             </div>
         </li>
        {% else %}

--- a/ckanext/bpatheme/templates/package/resource_read.html
+++ b/ckanext/bpatheme/templates/package/resource_read.html
@@ -36,6 +36,18 @@
                             resource_id=res.id
                             %}
                         </li>
+                        <li>
+                            <div>
+                                {% asset 'ckanext-bpatheme/drs-copy-js' %}
+                                <a href="#"
+                                   class="resource-url-analytics drs_copy_uri"
+                                   data-module="drs_copy_uri"
+                                   data-module-uri="{{ h.get_drs_uri(res.id) }}">
+                                    <i class="fa fa-copy download-window-links"></i>
+                                    {{ _('Copy DRS URI') }}
+                                </a>
+                            </div>
+                        </li>
                         {% endif %}
             {% if res.url and h.is_url(res.url) %}
               <li>

--- a/ckanext/bpatheme/templates/package/resource_read.html
+++ b/ckanext/bpatheme/templates/package/resource_read.html
@@ -37,16 +37,14 @@
                             %}
                         </li>
                         <li>
-                            <div>
-                                {% asset 'ckanext-bpatheme/drs-copy-js' %}
-                                <a href="#"
-                                   class="resource-url-analytics drs_copy_uri"
-                                   data-module="drs_copy_uri"
-                                   data-module-uri="{{ h.get_drs_uri(res.id) }}">
-                                    <i class="fa fa-copy download-window-links"></i>
-                                    {{ _('Copy DRS URI') }}
-                                </a>
-                            </div>
+                            {% asset 'ckanext-bpatheme/drs-copy-js' %}
+                            <a href="#"
+                               class="resource-url-analytics drs_copy_uri"
+                               data-module="drs_copy_uri"
+                               data-module-uri="{{ h.get_drs_uri(res.id) }}">
+                                <i class="fa fa-copy download-window-links"></i>
+                                {{ _('Copy DRS URL') }}
+                            </a>
                         </li>
                         {% endif %}
             {% if res.url and h.is_url(res.url) %}

--- a/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
+++ b/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
@@ -41,6 +41,18 @@
                         <li>
                             {% snippet 'ckanext_s3filestore/snippets/download_window_link.html', id=pkg.name, resource_id=res.id %}
                         </li>
+                        <li>
+                            <div>
+                                {% asset 'ckanext-bpatheme/drs-copy-js' %}
+                                <a href="#"
+                                   class="resource-url-analytics drs_copy_uri"
+                                   data-module="drs_copy_uri"
+                                   data-module-uri="{{ h.get_drs_uri(res.id) }}">
+                                    <i class="fa fa-copy download-window-links"></i>
+                                    {{ _('Copy DRS URI') }}
+                                </a>
+                            </div>
+                        </li>
                         {% endif %}
                         {% if can_edit %}
                         <li>

--- a/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
+++ b/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
@@ -42,16 +42,14 @@
                             {% snippet 'ckanext_s3filestore/snippets/download_window_link.html', id=pkg.name, resource_id=res.id %}
                         </li>
                         <li>
-                            <div>
-                                {% asset 'ckanext-bpatheme/drs-copy-js' %}
-                                <a href="#"
-                                   class="resource-url-analytics drs_copy_uri"
-                                   data-module="drs_copy_uri"
-                                   data-module-uri="{{ h.get_drs_uri(res.id) }}">
-                                    <i class="fa fa-copy download-window-links"></i>
-                                    {{ _('Copy DRS URI') }}
-                                </a>
-                            </div>
+                            {% asset 'ckanext-bpatheme/drs-copy-js' %}
+                            <a href="#"
+                               class="resource-url-analytics drs_copy_uri"
+                               data-module="drs_copy_uri"
+                               data-module-uri="{{ h.get_drs_uri(res.id) }}">
+                                <i class="fa fa-copy download-window-links"></i>
+                                {{ _('Copy DRS URL') }}
+                            </a>
                         </li>
                         {% endif %}
                         {% if can_edit %}


### PR DESCRIPTION
Adds "Copy DRS URL" to the Access dropdown on both the dataset resource list and individual resource page (accessible via "more information"), alongside the existing "Copy Download URL".

## Changes
- Added a `get_drs_uri` template helper that constructs a valid GA4GH DRS URL (https://{site}/ga4gh/drs/v1/objects/{id})
- Added a new JS module that copies the DRS URL to clipboard and shows a "Copied to clipboard!" confirmation popover
- Added a "Copy DRS URL" option to the Access dropdown on both the dataset resource list and the individual resource page

## UI changes
<img width="1512" height="623" alt="Screenshot 2026-04-14 at 7 43 40 pm" src="https://github.com/user-attachments/assets/ef5f10a1-b4d9-4c64-aa06-edb6a8d4dba9" />
<img width="1512" height="623" alt="Screenshot 2026-04-14 at 7 43 48 pm" src="https://github.com/user-attachments/assets/db9cb51d-7fc5-474b-917c-f4c45cdeaa2b" />
<img width="1512" height="623" alt="Screenshot 2026-04-14 at 7 44 01 pm" src="https://github.com/user-attachments/assets/1a948c8e-dae2-4d95-9ff1-433f4b64f6bb" />
<img width="1512" height="623" alt="Screenshot 2026-04-14 at 7 44 06 pm" src="https://github.com/user-attachments/assets/dbfd5a69-6f1d-499a-a3db-24628748144f" />


## Testing
With this following resource from TSI: https://aaidemo.bioplatforms.com/tsi-illumina-fastq/bpa-tsi-illumina-fastq-357631-h2kn2drxy, we access with the DRS url obtained from the "Copy DRS URL" button shown above:

1. Terminal access without authentication token via curl - no access 403:
```bash
 curl -s https://aaidemo.bioplatforms.com/ga4gh/drs/v1/objects/efface8b77d7399386aa2a2831f5a34c
{"status_code": 403, "msg": "Forbidden: you do not have permission to access object 'efface8b77d7399386aa2a2831f5a34c'"}
```

2. Terminal access with auth0 access token (note that this will only work if https://github.com/BioplatformsAustralia/ckanext-oidc-pkce-bpa/pull/23 is merged):
```bash
ubuntu@aai-demo-ckan:~/aai-demo/dockercompose-bpa-ckan/ckanext-bpatheme$ curl -s https://aaidemo.bioplatforms.com/ga4gh/drs/v1/objects/efface8b77d7399386aa2a2831f5a34c   -H "Authorization: Bearer <auth0-access-token>"
{"access_methods":[{"access_id":"download_window","type":"https"}],"aliases":["357631_TSI_UNSW_H2KN2DRXY_TATGTAGTCA-CATTAGTGCG_S8_L001_R2_001.fastq.gz"],"checksums":[{"checksum":"efface8b77d7399386aa2a2831f5a34c","type":"md5"}],"contents":[{"drs_uri":["drs://aaidemo.bioplatforms.com/efface8b77d7399386aa2a2831f5a34c"],"id":"efface8b77d7399386aa2a2831f5a34c","name":"357631_TSI_UNSW_H2KN2DRXY_TATGTAGTCA-CATTAGTGCG_S8_L001_R2_001.fastq.gz"}],"created_time":"2025-08-29T02:23:06.750134","description":"","id":"efface8b77d7399386aa2a2831f5a34c","mime_type":null,"name":"357631_TSI_UNSW_H2KN2DRXY_TATGTAGTCA-CATTAGTGCG_S8_L001_R2_001.fastq.gz","self_uri":"drs://aaidemo.bioplatforms.com/efface8b77d7399386aa2a2831f5a34c","size":null,"updated_time":null,"version":1}
```

3. Terminal access with CKAN API Key access token:
```bash
curl -s https://aaidemo.bioplatforms.com/ga4gh/drs/v1/objects/efface8b77d7399386aa2a2831f5a34c   -H "Authorization: Bearer <ckan-api-key>"
{"access_methods":[{"access_id":"download_window","type":"https"}],"aliases":["357631_TSI_UNSW_H2KN2DRXY_TATGTAGTCA-CATTAGTGCG_S8_L001_R2_001.fastq.gz"],"checksums":[{"checksum":"efface8b77d7399386aa2a2831f5a34c","type":"md5"}],"contents":[{"drs_uri":["drs://aaidemo.bioplatforms.com/efface8b77d7399386aa2a2831f5a34c"],"id":"efface8b77d7399386aa2a2831f5a34c","name":"357631_TSI_UNSW_H2KN2DRXY_TATGTAGTCA-CATTAGTGCG_S8_L001_R2_001.fastq.gz"}],"created_time":"2025-08-29T02:23:06.750134","description":"","id":"efface8b77d7399386aa2a2831f5a34c","mime_type":null,"name":"357631_TSI_UNSW_H2KN2DRXY_TATGTAGTCA-CATTAGTGCG_S8_L001_R2_001.fastq.gz","self_uri":"drs://aaidemo.bioplatforms.com/efface8b77d7399386aa2a2831f5a34c","size":null,"updated_time":null,"version":1}
```