### PR TITLE
Enable galaxy data transfer

### DIFF
--- a/ckanext/bpatheme/assets/scripts/drs_copy_uri.js
+++ b/ckanext/bpatheme/assets/scripts/drs_copy_uri.js
@@ -1,0 +1,40 @@
+'use strict';
+
+ckan.module('drs_copy_uri', function ($) {
+    return {
+        initialize: function () {
+            $.proxyAll(this, /_on/);
+            this.el.on('click', this._onClick);
+        },
+        _onClick: function (event) {
+            event.preventDefault();
+            var uri = this.options.uri;
+            if (!uri) {
+                this._toggleFeedback('No DRS URI available.');
+                return;
+            }
+            navigator.clipboard.writeText(uri).then(
+                this._onCopySuccess,
+                this._onCopyError
+            );
+        },
+        _onCopySuccess: function () {
+            this._toggleFeedback('DRS URI copied to clipboard.');
+        },
+        _onCopyError: function () {
+            this._toggleFeedback('Could not copy to clipboard.');
+        },
+        _toggleFeedback: function (message) {
+            var element = this.el.closest('div, li');
+            element.popover('destroy');
+            element.popover({
+                title: 'Copied!',
+                html: true,
+                content: message,
+                placement: 'left',
+            });
+            element.popover('show');
+            setTimeout(function () { element.popover('destroy'); }, 6000);
+        },
+    };
+});

--- a/ckanext/bpatheme/assets/scripts/galaxy_send.js
+++ b/ckanext/bpatheme/assets/scripts/galaxy_send.js
@@ -1,0 +1,248 @@
+'use strict';
+
+/*
+ * galaxy_send CKAN module
+ *
+ * Wires up the "Send to Galaxy Australia" dropdown item on resource pages and
+ * resource list cards.  Opens a Bootstrap modal, fetches the user's Galaxy
+ * histories via a CKAN server-side proxy, lets them pick one, then submits
+ * an upload job to Galaxy.
+ *
+ * Required data attributes on the trigger element:
+ *   data-module-resource-id   – CKAN resource UUID
+ *   data-module-package-id    – CKAN package name/id
+ *   data-module-resource-name – Human-readable resource name (shown in modal)
+ */
+
+ckan.module('galaxy_send', function ($) {
+
+    var MODAL_ID = 'galaxy-australia-modal';
+
+    // Build the modal DOM once and reuse it across all buttons on the page.
+    function _buildModal() {
+        var html = [
+            '<div class="modal fade" id="' + MODAL_ID + '" tabindex="-1" role="dialog"',
+            '     aria-labelledby="galaxy-modal-label">',
+            '  <div class="modal-dialog" role="document" style="max-width:600px">',
+            '    <div class="modal-content">',
+            '      <div class="modal-header">',
+            '        <button type="button" class="close" data-dismiss="modal" aria-label="Close">',
+            '          <span aria-hidden="true">&times;</span>',
+            '        </button>',
+            '        <h4 class="modal-title" id="galaxy-modal-label">',
+            '          <i class="fa fa-rocket"></i> Send to Galaxy Australia',
+            '        </h4>',
+            '      </div>',
+            '      <div class="modal-body">',
+            '        <p id="galaxy-modal-resource-name" class="text-muted small" style="margin-bottom:12px"></p>',
+            '        <div id="galaxy-modal-loading" class="text-center" style="padding:24px 0">',
+            '          <i class="fa fa-spinner fa-spin fa-2x"></i>',
+            '          <p style="margin-top:8px">Loading your Galaxy Australia histories&hellip;</p>',
+            '        </div>',
+            '        <div id="galaxy-modal-error" class="alert alert-danger" style="display:none"></div>',
+            '        <div id="galaxy-modal-histories" style="display:none">',
+            '          <p style="margin-bottom:6px"><strong>Select a history to send this file to:</strong></p>',
+            '          <div id="galaxy-history-list" class="list-group"',
+            '               style="max-height:320px;overflow-y:auto;border:1px solid #ddd;border-radius:4px">',
+            '          </div>',
+            '        </div>',
+            '        <div id="galaxy-modal-success" class="alert alert-success" style="display:none">',
+            '          <i class="fa fa-check"></i>',
+            '          Your file has been queued for upload in Galaxy Australia.',
+            '          <br><a href="https://usegalaxy.org.au" target="_blank" class="alert-link">',
+            '            Open Galaxy Australia <i class="fa fa-external-link"></i>',
+            '          </a>',
+            '        </div>',
+            '      </div>',
+            '      <div class="modal-footer">',
+            '        <a href="https://usegalaxy.org.au" target="_blank"',
+            '           class="btn btn-default pull-left"',
+            '           title="Open Galaxy Australia in a new tab">',
+            '          <i class="fa fa-external-link"></i> Galaxy Australia',
+            '        </a>',
+            '        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>',
+            '        <button type="button" class="btn btn-primary" id="galaxy-modal-send-btn" disabled>',
+            '          <i class="fa fa-rocket"></i> Send to Galaxy',
+            '        </button>',
+            '      </div>',
+            '    </div>',
+            '  </div>',
+            '</div>',
+        ].join('\n');
+
+        $('body').append(html);
+        return $('#' + MODAL_ID);
+    }
+
+    return {
+        options: {
+            resourceId: null,
+            packageId: null,
+            resourceName: null,
+        },
+
+        initialize: function () {
+            $.proxyAll(this, /_on/);
+            this.el.on('click', this._onClick);
+        },
+
+        _getModal: function () {
+            var existing = $('#' + MODAL_ID);
+            return existing.length ? existing : _buildModal();
+        },
+
+        _onClick: function (e) {
+            e.preventDefault();
+            this._selectedHistoryId = null;
+            var modal = this._getModal();
+
+            // Reset state
+            modal.find('#galaxy-modal-resource-name').text(
+                this.options.resourceName ? 'File: ' + this.options.resourceName : ''
+            );
+            modal.find('#galaxy-modal-loading').show();
+            modal.find('#galaxy-modal-histories').hide();
+            modal.find('#galaxy-modal-error').hide().text('');
+            modal.find('#galaxy-modal-success').hide();
+            modal.find('#galaxy-history-list').empty();
+            modal.find('#galaxy-modal-send-btn')
+                .prop('disabled', true)
+                .off('click')
+                .on('click', this._onSendClick);
+
+            modal.modal('show');
+            this._fetchHistories(modal);
+        },
+
+        _fetchHistories: function (modal) {
+            var self = this;
+            $.ajax({
+                url: '/api/galaxy/histories',
+                method: 'GET',
+                success: function (data) { self._onHistoriesReceived(modal, data); },
+                error: function (xhr) { self._onHistoriesFailed(modal, xhr); },
+            });
+        },
+
+        _onHistoriesReceived: function (modal, data) {
+            modal.find('#galaxy-modal-loading').hide();
+
+            if (!data || data.error) {
+                var msg = (data && data.error) || 'Unknown error fetching histories.';
+                this._showError(modal, msg);
+                return;
+            }
+
+            if (!data.length) {
+                this._showError(
+                    modal,
+                    'No Galaxy Australia histories found. ' +
+                    'Please <a href="https://usegalaxy.org.au" target="_blank">open Galaxy Australia</a> ' +
+                    'and create a history, then try again.'
+                );
+                return;
+            }
+
+            var listEl = modal.find('#galaxy-history-list').empty();
+            var self = this;
+
+            data.forEach(function (history) {
+                var dateStr = (history.update_time || '').split('T')[0];
+                var sizeStr = history.nice_size ? ' &mdash; ' + history.nice_size : '';
+                var label = '<strong>' + _escHtml(history.name) + '</strong>' +
+                            (dateStr ? '<span class="text-muted"> &nbsp;' + dateStr + '</span>' : '') +
+                            sizeStr;
+
+                var item = $('<a class="list-group-item" href="#" role="button"></a>')
+                    .attr('data-history-id', history.id)
+                    .html('<i class="fa fa-history text-muted" style="margin-right:6px"></i>' + label);
+
+                item.on('click', function (e) {
+                    e.preventDefault();
+                    self._onHistorySelect(modal, history.id, $(this));
+                });
+
+                listEl.append(item);
+            });
+
+            modal.find('#galaxy-modal-histories').show();
+        },
+
+        _onHistoriesFailed: function (modal, xhr) {
+            modal.find('#galaxy-modal-loading').hide();
+            var msg = 'Could not load Galaxy Australia histories.';
+            try {
+                var body = JSON.parse(xhr.responseText);
+                if (body && body.error) { msg = body.error; }
+            } catch (ignored) {}
+            this._showError(modal, msg);
+        },
+
+        _onHistorySelect: function (modal, historyId, itemEl) {
+            modal.find('#galaxy-history-list .list-group-item').removeClass('active');
+            itemEl.addClass('active');
+            this._selectedHistoryId = historyId;
+            modal.find('#galaxy-modal-send-btn').prop('disabled', false);
+        },
+
+        _onSendClick: function () {
+            var modal = this._getModal();
+            if (!this._selectedHistoryId) { return; }
+
+            var sendBtn = modal.find('#galaxy-modal-send-btn');
+            sendBtn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Sending&hellip;');
+
+            var self = this;
+            $.ajax({
+                url: '/api/galaxy/send',
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({
+                    history_id: self._selectedHistoryId,
+                    package_id: self.options.packageId,
+                    resource_id: self.options.resourceId,
+                }),
+                success: function (data) { self._onSendSuccess(modal, data); },
+                error: function (xhr) { self._onSendFailed(modal, xhr, sendBtn); },
+            });
+        },
+
+        _onSendSuccess: function (modal, data) {
+            // Galaxy returns 200 even for queued jobs; check for error key
+            if (data && data.err_msg) {
+                this._onSendFailed(modal, { responseText: JSON.stringify({ error: data.err_msg }) },
+                    modal.find('#galaxy-modal-send-btn'));
+                return;
+            }
+            modal.find('#galaxy-modal-histories').hide();
+            modal.find('#galaxy-modal-error').hide();
+            modal.find('#galaxy-modal-send-btn').hide();
+            modal.find('#galaxy-modal-success').show();
+        },
+
+        _onSendFailed: function (modal, xhr, sendBtn) {
+            var msg = 'Failed to send file to Galaxy Australia.';
+            try {
+                var body = JSON.parse(xhr.responseText);
+                if (body && body.error) { msg = body.error; }
+            } catch (ignored) {}
+            sendBtn.prop('disabled', false)
+                   .html('<i class="fa fa-rocket"></i> Send to Galaxy');
+            this._showError(modal, msg);
+        },
+
+        _showError: function (modal, message) {
+            modal.find('#galaxy-modal-error').html(
+                '<i class="fa fa-exclamation-triangle"></i> ' + message
+            ).show();
+        },
+    };
+});
+
+function _escHtml(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}

--- a/ckanext/bpatheme/assets/scripts/galaxy_send.js
+++ b/ckanext/bpatheme/assets/scripts/galaxy_send.js
@@ -3,11 +3,8 @@
 /*
  * galaxy_send CKAN module
  *
- * Two-step modal:
- *   1. If no Galaxy API key is stored in the CKAN session, show a "Connect"
- *      step where the user pastes their key (User → Preferences → API Key in Galaxy).
- *   2. Once connected, show the user's histories and let them pick one.
- *      CKAN proxies all Galaxy API calls server-side using the stored key.
+ * Authenticates to Galaxy Australia using the Auth0 Bearer token from the
+ * user's existing CKAN OIDC session — no separate Galaxy API key needed.
  *
  * Required data attributes on the trigger element:
  *   data-module-resource-id   – CKAN resource UUID
@@ -22,7 +19,6 @@ ckan.module('galaxy_send', function ($) {
 
     function _buildModal(galaxyUrl) {
         var safeUrl = _escAttr(galaxyUrl);
-        var apiKeyHelpUrl = safeUrl + '/user/api_key';
         var html = [
             '<div class="modal fade" id="' + MODAL_ID + '" tabindex="-1" role="dialog"',
             '     aria-labelledby="galaxy-modal-label">',
@@ -41,27 +37,6 @@ ckan.module('galaxy_send', function ($) {
             '      <div class="modal-body">',
             '        <p id="galaxy-modal-resource-name" class="text-muted small" style="margin-bottom:12px"></p>',
 
-            /* ── API key step ── */
-            '        <div id="galaxy-modal-key-step" style="display:none">',
-            '          <p>',
-            '            Enter your <strong>Galaxy Australia API key</strong> to connect.',
-            '            <a href="' + apiKeyHelpUrl + '" target="_blank">',
-            '              Find it under User &rarr; Preferences &rarr; Manage API Key',
-            '              <i class="fa fa-external-link"></i>',
-            '            </a>.',
-            '          </p>',
-            '          <div class="input-group">',
-            '            <input type="password" id="galaxy-api-key-input" class="form-control"',
-            '                   placeholder="Paste your Galaxy API key here" autocomplete="off">',
-            '            <span class="input-group-btn">',
-            '              <button class="btn btn-primary" id="galaxy-connect-btn">',
-            '                <i class="fa fa-plug"></i> Connect',
-            '              </button>',
-            '            </span>',
-            '          </div>',
-            '          <div id="galaxy-key-error" class="text-danger small" style="margin-top:6px;display:none"></div>',
-            '        </div>',
-
             /* ── loading spinner ── */
             '        <div id="galaxy-modal-loading" class="text-center" style="padding:24px 0;display:none">',
             '          <i class="fa fa-spinner fa-spin fa-2x"></i>',
@@ -77,11 +52,6 @@ ckan.module('galaxy_send', function ($) {
             '          <div id="galaxy-history-list" class="list-group"',
             '               style="max-height:320px;overflow-y:auto;border:1px solid #ddd;border-radius:4px">',
             '          </div>',
-            '          <p class="text-right" style="margin-top:6px;margin-bottom:0">',
-            '            <a href="#" id="galaxy-change-key-link" class="small text-muted">',
-            '              <i class="fa fa-key"></i> Change API key',
-            '            </a>',
-            '          </p>',
             '        </div>',
 
             /* ── success ── */
@@ -103,7 +73,7 @@ ckan.module('galaxy_send', function ($) {
             '        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>',
             '        <button type="button" class="btn btn-primary" id="galaxy-modal-send-btn"',
             '                style="display:none" disabled>',
-            '          <i class="fa fa-rocket"></i> Send to Galaxy',
+            '          <i class="fa fa-rocket"></i> Bulk send to Galaxy',
             '        </button>',
             '      </div>',
 
@@ -142,9 +112,6 @@ ckan.module('galaxy_send', function ($) {
             modal.find('#galaxy-modal-resource-name').text(
                 this.options.resourceName ? 'File: ' + this.options.resourceName : ''
             );
-            // Wire up persistent buttons (they survive modal reuse)
-            modal.find('#galaxy-connect-btn').off('click').on('click', this._onConnectClick);
-            modal.find('#galaxy-change-key-link').off('click').on('click', this._onChangeKeyClick);
             modal.find('#galaxy-modal-send-btn')
                 .off('click').on('click', this._onSendClick)
                 .prop('disabled', true).show()
@@ -156,25 +123,12 @@ ckan.module('galaxy_send', function ($) {
         },
 
         _resetModal: function (modal) {
-            modal.find('#galaxy-modal-key-step').hide();
             modal.find('#galaxy-modal-loading').hide();
             modal.find('#galaxy-modal-error').hide().text('');
             modal.find('#galaxy-modal-histories').hide();
             modal.find('#galaxy-modal-success').hide();
             modal.find('#galaxy-modal-send-btn').hide();
-            modal.find('#galaxy-api-key-input').val('');
-            modal.find('#galaxy-key-error').hide().text('');
             modal.find('#galaxy-history-list').empty();
-        },
-
-        _showKeyStep: function (modal, errorMsg) {
-            modal.find('#galaxy-modal-loading').hide();
-            modal.find('#galaxy-modal-histories').hide();
-            modal.find('#galaxy-modal-send-btn').hide();
-            modal.find('#galaxy-modal-key-step').show();
-            if (errorMsg) {
-                modal.find('#galaxy-key-error').text(errorMsg).show();
-            }
         },
 
         _loadHistories: function (modal) {
@@ -198,7 +152,6 @@ ckan.module('galaxy_send', function ($) {
                     'Please <a href="' + _escHtml(this.options.galaxyUrl) + '" target="_blank">open Galaxy Australia</a> ' +
                     'and create a history first.'
                 ).show();
-                modal.find('#galaxy-modal-histories').hide();
                 modal.find('#galaxy-modal-send-btn').hide();
                 return;
             }
@@ -231,68 +184,18 @@ ckan.module('galaxy_send', function ($) {
 
         _onHistoriesFailed: function (modal, xhr) {
             modal.find('#galaxy-modal-loading').hide();
-            // 401 with error=no_api_key means we need the user to enter their key
-            if (xhr.status === 401) {
-                try {
-                    var body = JSON.parse(xhr.responseText);
-                    if (body.error === 'no_api_key') {
-                        this._showKeyStep(modal);
-                        return;
-                    }
-                } catch (ignored) {}
-            }
-            // 401 with a different message means the stored key was rejected by Galaxy
-            if (xhr.status === 401 || xhr.status === 403) {
-                this._showKeyStep(modal, 'Your Galaxy API key was rejected. Please enter a valid key.');
-                return;
-            }
             var msg = 'Could not load Galaxy Australia histories.';
             try {
                 var b = JSON.parse(xhr.responseText);
                 if (b && b.error) { msg = b.error; }
             } catch (ignored) {}
+            if (xhr.status === 401 || xhr.status === 403) {
+                msg = 'Authentication failed. Please ensure you are logged in via your institutional account, which must be linked to Galaxy Australia.';
+            }
             modal.find('#galaxy-modal-error').html(
                 '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg)
             ).show();
-        },
-
-        _onConnectClick: function () {
-            var modal = this._getModal();
-            var apiKey = modal.find('#galaxy-api-key-input').val().trim();
-            if (!apiKey) {
-                modal.find('#galaxy-key-error').text('Please enter an API key.').show();
-                return;
-            }
-            var connectBtn = modal.find('#galaxy-connect-btn');
-            connectBtn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i>');
-            modal.find('#galaxy-key-error').hide();
-            var self = this;
-
-            $.ajax({
-                url: '/galaxy/set-api-key',
-                method: 'POST',
-                contentType: 'application/json',
-                data: JSON.stringify({ api_key: apiKey }),
-                success: function () {
-                    connectBtn.prop('disabled', false).html('<i class="fa fa-plug"></i> Connect');
-                    modal.find('#galaxy-modal-key-step').hide();
-                    self._loadHistories(modal);
-                },
-                error: function () {
-                    connectBtn.prop('disabled', false).html('<i class="fa fa-plug"></i> Connect');
-                    modal.find('#galaxy-key-error').text('Could not save API key. Please try again.').show();
-                },
-            });
-        },
-
-        _onChangeKeyClick: function (e) {
-            e.preventDefault();
-            var modal = this._getModal();
-            modal.find('#galaxy-modal-histories').hide();
             modal.find('#galaxy-modal-send-btn').hide();
-            modal.find('#galaxy-api-key-input').val('');
-            modal.find('#galaxy-key-error').hide().text('');
-            modal.find('#galaxy-modal-key-step').show();
         },
 
         _onSendClick: function () {
@@ -302,15 +205,19 @@ ckan.module('galaxy_send', function ($) {
             sendBtn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Sending&hellip;');
             var self = this;
 
+            // Bundle mode: no resourceId → send entire package via DRS bundle URI
+            var isBundleMode = !self.options.resourceId;
+            var url = isBundleMode ? '/galaxy/send-bundle' : '/galaxy/send';
+            var payload = isBundleMode
+                ? { history_id: self._selectedHistoryId, package_id: self.options.packageId }
+                : { history_id: self._selectedHistoryId, package_id: self.options.packageId,
+                    resource_id: self.options.resourceId, resource_name: self.options.resourceName };
+
             $.ajax({
-                url: '/galaxy/send',
+                url: url,
                 method: 'POST',
                 contentType: 'application/json',
-                data: JSON.stringify({
-                    history_id: self._selectedHistoryId,
-                    package_id: self.options.packageId,
-                    resource_id: self.options.resourceId,
-                }),
+                data: JSON.stringify(payload),
                 success: function (data) {
                     if (data && data.err_msg) {
                         sendBtn.prop('disabled', false).html('<i class="fa fa-rocket"></i> Send to Galaxy');

--- a/ckanext/bpatheme/assets/scripts/galaxy_send.js
+++ b/ckanext/bpatheme/assets/scripts/galaxy_send.js
@@ -3,28 +3,32 @@
 /*
  * galaxy_send CKAN module
  *
- * Wires up the "Send to Galaxy Australia" dropdown item on resource pages and
- * resource list cards.  Opens a Bootstrap modal, fetches the user's Galaxy
- * histories via a CKAN server-side proxy, lets them pick one, then submits
- * an upload job to Galaxy.
+ * Two-step modal:
+ *   1. If no Galaxy API key is stored in the CKAN session, show a "Connect"
+ *      step where the user pastes their key (User → Preferences → API Key in Galaxy).
+ *   2. Once connected, show the user's histories and let them pick one.
+ *      CKAN proxies all Galaxy API calls server-side using the stored key.
  *
  * Required data attributes on the trigger element:
  *   data-module-resource-id   – CKAN resource UUID
  *   data-module-package-id    – CKAN package name/id
- *   data-module-resource-name – Human-readable resource name (shown in modal)
+ *   data-module-resource-name – Human-readable resource name
+ *   data-module-galaxy-url    – Galaxy instance base URL (for links only)
  */
 
 ckan.module('galaxy_send', function ($) {
 
     var MODAL_ID = 'galaxy-australia-modal';
 
-    // Build the modal DOM once and reuse it across all buttons on the page.
-    function _buildModal() {
+    function _buildModal(galaxyUrl) {
+        var safeUrl = _escAttr(galaxyUrl);
+        var apiKeyHelpUrl = safeUrl + '/user/api_key';
         var html = [
             '<div class="modal fade" id="' + MODAL_ID + '" tabindex="-1" role="dialog"',
             '     aria-labelledby="galaxy-modal-label">',
             '  <div class="modal-dialog" role="document" style="max-width:600px">',
             '    <div class="modal-content">',
+
             '      <div class="modal-header">',
             '        <button type="button" class="close" data-dismiss="modal" aria-label="Close">',
             '          <span aria-hidden="true">&times;</span>',
@@ -33,38 +37,76 @@ ckan.module('galaxy_send', function ($) {
             '          <i class="fa fa-rocket"></i> Send to Galaxy Australia',
             '        </h4>',
             '      </div>',
+
             '      <div class="modal-body">',
             '        <p id="galaxy-modal-resource-name" class="text-muted small" style="margin-bottom:12px"></p>',
-            '        <div id="galaxy-modal-loading" class="text-center" style="padding:24px 0">',
+
+            /* ── API key step ── */
+            '        <div id="galaxy-modal-key-step" style="display:none">',
+            '          <p>',
+            '            Enter your <strong>Galaxy Australia API key</strong> to connect.',
+            '            <a href="' + apiKeyHelpUrl + '" target="_blank">',
+            '              Find it under User &rarr; Preferences &rarr; Manage API Key',
+            '              <i class="fa fa-external-link"></i>',
+            '            </a>.',
+            '          </p>',
+            '          <div class="input-group">',
+            '            <input type="password" id="galaxy-api-key-input" class="form-control"',
+            '                   placeholder="Paste your Galaxy API key here" autocomplete="off">',
+            '            <span class="input-group-btn">',
+            '              <button class="btn btn-primary" id="galaxy-connect-btn">',
+            '                <i class="fa fa-plug"></i> Connect',
+            '              </button>',
+            '            </span>',
+            '          </div>',
+            '          <div id="galaxy-key-error" class="text-danger small" style="margin-top:6px;display:none"></div>',
+            '        </div>',
+
+            /* ── loading spinner ── */
+            '        <div id="galaxy-modal-loading" class="text-center" style="padding:24px 0;display:none">',
             '          <i class="fa fa-spinner fa-spin fa-2x"></i>',
             '          <p style="margin-top:8px">Loading your Galaxy Australia histories&hellip;</p>',
             '        </div>',
+
+            /* ── general error ── */
             '        <div id="galaxy-modal-error" class="alert alert-danger" style="display:none"></div>',
+
+            /* ── history list ── */
             '        <div id="galaxy-modal-histories" style="display:none">',
             '          <p style="margin-bottom:6px"><strong>Select a history to send this file to:</strong></p>',
             '          <div id="galaxy-history-list" class="list-group"',
             '               style="max-height:320px;overflow-y:auto;border:1px solid #ddd;border-radius:4px">',
             '          </div>',
+            '          <p class="text-right" style="margin-top:6px;margin-bottom:0">',
+            '            <a href="#" id="galaxy-change-key-link" class="small text-muted">',
+            '              <i class="fa fa-key"></i> Change API key',
+            '            </a>',
+            '          </p>',
             '        </div>',
+
+            /* ── success ── */
             '        <div id="galaxy-modal-success" class="alert alert-success" style="display:none">',
             '          <i class="fa fa-check"></i>',
             '          Your file has been queued for upload in Galaxy Australia.',
-            '          <br><a href="https://usegalaxy.org.au" target="_blank" class="alert-link">',
+            '          <br><a href="' + safeUrl + '" target="_blank" class="alert-link">',
             '            Open Galaxy Australia <i class="fa fa-external-link"></i>',
             '          </a>',
             '        </div>',
             '      </div>',
+
             '      <div class="modal-footer">',
-            '        <a href="https://usegalaxy.org.au" target="_blank"',
+            '        <a href="' + safeUrl + '" target="_blank"',
             '           class="btn btn-default pull-left"',
             '           title="Open Galaxy Australia in a new tab">',
             '          <i class="fa fa-external-link"></i> Galaxy Australia',
             '        </a>',
             '        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>',
-            '        <button type="button" class="btn btn-primary" id="galaxy-modal-send-btn" disabled>',
+            '        <button type="button" class="btn btn-primary" id="galaxy-modal-send-btn"',
+            '                style="display:none" disabled>',
             '          <i class="fa fa-rocket"></i> Send to Galaxy',
             '        </button>',
             '      </div>',
+
             '    </div>',
             '  </div>',
             '</div>',
@@ -79,6 +121,7 @@ ckan.module('galaxy_send', function ($) {
             resourceId: null,
             packageId: null,
             resourceName: null,
+            galaxyUrl: 'https://usegalaxy.org.au',
         },
 
         initialize: function () {
@@ -88,7 +131,7 @@ ckan.module('galaxy_send', function ($) {
 
         _getModal: function () {
             var existing = $('#' + MODAL_ID);
-            return existing.length ? existing : _buildModal();
+            return existing.length ? existing : _buildModal(this.options.galaxyUrl);
         },
 
         _onClick: function (e) {
@@ -96,28 +139,49 @@ ckan.module('galaxy_send', function ($) {
             this._selectedHistoryId = null;
             var modal = this._getModal();
 
-            // Reset state
             modal.find('#galaxy-modal-resource-name').text(
                 this.options.resourceName ? 'File: ' + this.options.resourceName : ''
             );
-            modal.find('#galaxy-modal-loading').show();
-            modal.find('#galaxy-modal-histories').hide();
-            modal.find('#galaxy-modal-error').hide().text('');
-            modal.find('#galaxy-modal-success').hide();
-            modal.find('#galaxy-history-list').empty();
+            // Wire up persistent buttons (they survive modal reuse)
+            modal.find('#galaxy-connect-btn').off('click').on('click', this._onConnectClick);
+            modal.find('#galaxy-change-key-link').off('click').on('click', this._onChangeKeyClick);
             modal.find('#galaxy-modal-send-btn')
-                .prop('disabled', true)
-                .off('click')
-                .on('click', this._onSendClick);
+                .off('click').on('click', this._onSendClick)
+                .prop('disabled', true).show()
+                .html('<i class="fa fa-rocket"></i> Send to Galaxy');
 
+            this._resetModal(modal);
             modal.modal('show');
-            this._fetchHistories(modal);
+            this._loadHistories(modal);
         },
 
-        _fetchHistories: function (modal) {
+        _resetModal: function (modal) {
+            modal.find('#galaxy-modal-key-step').hide();
+            modal.find('#galaxy-modal-loading').hide();
+            modal.find('#galaxy-modal-error').hide().text('');
+            modal.find('#galaxy-modal-histories').hide();
+            modal.find('#galaxy-modal-success').hide();
+            modal.find('#galaxy-modal-send-btn').hide();
+            modal.find('#galaxy-api-key-input').val('');
+            modal.find('#galaxy-key-error').hide().text('');
+            modal.find('#galaxy-history-list').empty();
+        },
+
+        _showKeyStep: function (modal, errorMsg) {
+            modal.find('#galaxy-modal-loading').hide();
+            modal.find('#galaxy-modal-histories').hide();
+            modal.find('#galaxy-modal-send-btn').hide();
+            modal.find('#galaxy-modal-key-step').show();
+            if (errorMsg) {
+                modal.find('#galaxy-key-error').text(errorMsg).show();
+            }
+        },
+
+        _loadHistories: function (modal) {
             var self = this;
+            modal.find('#galaxy-modal-loading').show();
             $.ajax({
-                url: '/api/galaxy/histories',
+                url: '/galaxy/histories',
                 method: 'GET',
                 success: function (data) { self._onHistoriesReceived(modal, data); },
                 error: function (xhr) { self._onHistoriesFailed(modal, xhr); },
@@ -127,19 +191,15 @@ ckan.module('galaxy_send', function ($) {
         _onHistoriesReceived: function (modal, data) {
             modal.find('#galaxy-modal-loading').hide();
 
-            if (!data || data.error) {
-                var msg = (data && data.error) || 'Unknown error fetching histories.';
-                this._showError(modal, msg);
-                return;
-            }
-
-            if (!data.length) {
-                this._showError(
-                    modal,
-                    'No Galaxy Australia histories found. ' +
-                    'Please <a href="https://usegalaxy.org.au" target="_blank">open Galaxy Australia</a> ' +
-                    'and create a history, then try again.'
-                );
+            if (!Array.isArray(data) || !data.length) {
+                modal.find('#galaxy-modal-error').html(
+                    '<i class="fa fa-exclamation-triangle"></i> ' +
+                    'No histories found in Galaxy Australia. ' +
+                    'Please <a href="' + _escHtml(this.options.galaxyUrl) + '" target="_blank">open Galaxy Australia</a> ' +
+                    'and create a history first.'
+                ).show();
+                modal.find('#galaxy-modal-histories').hide();
+                modal.find('#galaxy-modal-send-btn').hide();
                 return;
             }
 
@@ -152,49 +212,98 @@ ckan.module('galaxy_send', function ($) {
                 var label = '<strong>' + _escHtml(history.name) + '</strong>' +
                             (dateStr ? '<span class="text-muted"> &nbsp;' + dateStr + '</span>' : '') +
                             sizeStr;
-
                 var item = $('<a class="list-group-item" href="#" role="button"></a>')
                     .attr('data-history-id', history.id)
                     .html('<i class="fa fa-history text-muted" style="margin-right:6px"></i>' + label);
-
                 item.on('click', function (e) {
                     e.preventDefault();
-                    self._onHistorySelect(modal, history.id, $(this));
+                    modal.find('#galaxy-history-list .list-group-item').removeClass('active');
+                    $(this).addClass('active');
+                    self._selectedHistoryId = history.id;
+                    modal.find('#galaxy-modal-send-btn').prop('disabled', false);
                 });
-
                 listEl.append(item);
             });
 
             modal.find('#galaxy-modal-histories').show();
+            modal.find('#galaxy-modal-send-btn').show().prop('disabled', true);
         },
 
         _onHistoriesFailed: function (modal, xhr) {
             modal.find('#galaxy-modal-loading').hide();
+            // 401 with error=no_api_key means we need the user to enter their key
+            if (xhr.status === 401) {
+                try {
+                    var body = JSON.parse(xhr.responseText);
+                    if (body.error === 'no_api_key') {
+                        this._showKeyStep(modal);
+                        return;
+                    }
+                } catch (ignored) {}
+            }
+            // 401 with a different message means the stored key was rejected by Galaxy
+            if (xhr.status === 401 || xhr.status === 403) {
+                this._showKeyStep(modal, 'Your Galaxy API key was rejected. Please enter a valid key.');
+                return;
+            }
             var msg = 'Could not load Galaxy Australia histories.';
             try {
-                var body = JSON.parse(xhr.responseText);
-                if (body && body.error) { msg = body.error; }
+                var b = JSON.parse(xhr.responseText);
+                if (b && b.error) { msg = b.error; }
             } catch (ignored) {}
-            this._showError(modal, msg);
+            modal.find('#galaxy-modal-error').html(
+                '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg)
+            ).show();
         },
 
-        _onHistorySelect: function (modal, historyId, itemEl) {
-            modal.find('#galaxy-history-list .list-group-item').removeClass('active');
-            itemEl.addClass('active');
-            this._selectedHistoryId = historyId;
-            modal.find('#galaxy-modal-send-btn').prop('disabled', false);
+        _onConnectClick: function () {
+            var modal = this._getModal();
+            var apiKey = modal.find('#galaxy-api-key-input').val().trim();
+            if (!apiKey) {
+                modal.find('#galaxy-key-error').text('Please enter an API key.').show();
+                return;
+            }
+            var connectBtn = modal.find('#galaxy-connect-btn');
+            connectBtn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i>');
+            modal.find('#galaxy-key-error').hide();
+            var self = this;
+
+            $.ajax({
+                url: '/galaxy/set-api-key',
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ api_key: apiKey }),
+                success: function () {
+                    connectBtn.prop('disabled', false).html('<i class="fa fa-plug"></i> Connect');
+                    modal.find('#galaxy-modal-key-step').hide();
+                    self._loadHistories(modal);
+                },
+                error: function () {
+                    connectBtn.prop('disabled', false).html('<i class="fa fa-plug"></i> Connect');
+                    modal.find('#galaxy-key-error').text('Could not save API key. Please try again.').show();
+                },
+            });
+        },
+
+        _onChangeKeyClick: function (e) {
+            e.preventDefault();
+            var modal = this._getModal();
+            modal.find('#galaxy-modal-histories').hide();
+            modal.find('#galaxy-modal-send-btn').hide();
+            modal.find('#galaxy-api-key-input').val('');
+            modal.find('#galaxy-key-error').hide().text('');
+            modal.find('#galaxy-modal-key-step').show();
         },
 
         _onSendClick: function () {
             var modal = this._getModal();
             if (!this._selectedHistoryId) { return; }
-
             var sendBtn = modal.find('#galaxy-modal-send-btn');
             sendBtn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Sending&hellip;');
-
             var self = this;
+
             $.ajax({
-                url: '/api/galaxy/send',
+                url: '/galaxy/send',
                 method: 'POST',
                 contentType: 'application/json',
                 data: JSON.stringify({
@@ -202,47 +311,36 @@ ckan.module('galaxy_send', function ($) {
                     package_id: self.options.packageId,
                     resource_id: self.options.resourceId,
                 }),
-                success: function (data) { self._onSendSuccess(modal, data); },
-                error: function (xhr) { self._onSendFailed(modal, xhr, sendBtn); },
+                success: function (data) {
+                    if (data && data.err_msg) {
+                        sendBtn.prop('disabled', false).html('<i class="fa fa-rocket"></i> Send to Galaxy');
+                        modal.find('#galaxy-modal-error').html(
+                            '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(data.err_msg)
+                        ).show();
+                        return;
+                    }
+                    modal.find('#galaxy-modal-histories').hide();
+                    modal.find('#galaxy-modal-error').hide();
+                    modal.find('#galaxy-modal-send-btn').hide();
+                    modal.find('#galaxy-modal-success').show();
+                },
+                error: function (xhr) {
+                    sendBtn.prop('disabled', false).html('<i class="fa fa-rocket"></i> Send to Galaxy');
+                    var msg = 'Failed to send to Galaxy Australia.';
+                    try { var b = JSON.parse(xhr.responseText); if (b && b.error) { msg = b.error; } } catch (ignored) {}
+                    modal.find('#galaxy-modal-error').html(
+                        '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg)
+                    ).show();
+                },
             });
-        },
-
-        _onSendSuccess: function (modal, data) {
-            // Galaxy returns 200 even for queued jobs; check for error key
-            if (data && data.err_msg) {
-                this._onSendFailed(modal, { responseText: JSON.stringify({ error: data.err_msg }) },
-                    modal.find('#galaxy-modal-send-btn'));
-                return;
-            }
-            modal.find('#galaxy-modal-histories').hide();
-            modal.find('#galaxy-modal-error').hide();
-            modal.find('#galaxy-modal-send-btn').hide();
-            modal.find('#galaxy-modal-success').show();
-        },
-
-        _onSendFailed: function (modal, xhr, sendBtn) {
-            var msg = 'Failed to send file to Galaxy Australia.';
-            try {
-                var body = JSON.parse(xhr.responseText);
-                if (body && body.error) { msg = body.error; }
-            } catch (ignored) {}
-            sendBtn.prop('disabled', false)
-                   .html('<i class="fa fa-rocket"></i> Send to Galaxy');
-            this._showError(modal, msg);
-        },
-
-        _showError: function (modal, message) {
-            modal.find('#galaxy-modal-error').html(
-                '<i class="fa fa-exclamation-triangle"></i> ' + message
-            ).show();
         },
     };
 });
 
 function _escHtml(str) {
     return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+function _escAttr(str) {
+    return String(str).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }

--- a/ckanext/bpatheme/assets/webassets.yml
+++ b/ckanext/bpatheme/assets/webassets.yml
@@ -44,6 +44,15 @@ bootstraptable-css:
   contents:
      - bootstraptable/bootstrap-table.min.css
 
+drs-copy-js:
+  filters: rjsmin
+  output: ckanext-bpatheme/%(version)s_drs_copy.js
+  contents:
+     - scripts/drs_copy_uri.js
+  extra:
+    preload:
+      - base/main
+
 galaxy-send-js:
   filters: rjsmin
   output: ckanext-bpatheme/%(version)s_galaxy_send.js

--- a/ckanext/bpatheme/assets/webassets.yml
+++ b/ckanext/bpatheme/assets/webassets.yml
@@ -43,3 +43,12 @@ bootstraptable-css:
   output: ckanext-bpatheme/%(version)s_bootstraptable.css
   contents:
      - bootstraptable/bootstrap-table.min.css
+
+galaxy-send-js:
+  filters: rjsmin
+  output: ckanext-bpatheme/%(version)s_galaxy_send.js
+  contents:
+     - scripts/galaxy_send.js
+  extra:
+    preload:
+      - base/main

--- a/ckanext/bpatheme/blueprint.py
+++ b/ckanext/bpatheme/blueprint.py
@@ -10,7 +10,7 @@ import hashlib
 import requests as http_requests
 from logging import getLogger
 
-from ckan.common import g, session
+from ckan.common import g, session, config
 import ckan.lib.base as base
 import ckan.lib.helpers as h
 import ckan.logic as logic
@@ -19,8 +19,17 @@ from ckan.plugins.toolkit import (
     abort,
 )
 
-GALAXY_AU_URL = os.environ.get("GALAXY_AU_URL", "https://usegalaxy.org.au")
-SESSION_GALAXY_TOKEN = "ckanext:bpa:galaxy_access_token"
+SESSION_GALAXY_API_KEY = "ckanext:bpa:galaxy_api_key"
+
+
+def _galaxy_url():
+    return (config.get("ckanext.bpatheme.galaxy_url") or
+            os.environ.get("GALAXY_AU_URL", "https://usegalaxy.org.au")).rstrip("/")
+
+
+def _galaxy_fallback_key():
+    return (config.get("ckanext.bpatheme.galaxy_api_key") or
+            os.environ.get("GALAXY_API_KEY", ""))
 
 log = getLogger(__name__)
 
@@ -112,65 +121,94 @@ def cart_index(target_user):
     return render("shopping_cart/cart.html",extra_vars={ "user_dict": user_dict })
 
 
-# Galaxy Australia proxy: list user's histories
-def galaxy_histories():
+# Galaxy Australia — store the user's Galaxy API key in their CKAN session.
+def galaxy_set_api_key():
+    log.info("galaxy_set_api_key: called, g.user=%s", g.user)
     if not g.user:
+        log.warning("galaxy_set_api_key: unauthenticated request")
         return make_response(json.dumps({"error": "Not authenticated"}), 403)
+    body = flask_request.get_json(silent=True) or {}
+    api_key = (body.get("api_key") or "").strip()
+    if api_key:
+        session[SESSION_GALAXY_API_KEY] = api_key
+        log.info("galaxy_set_api_key: stored key for user=%s (len=%d)", g.user, len(api_key))
+    else:
+        session.pop(SESSION_GALAXY_API_KEY, None)
+        log.info("galaxy_set_api_key: cleared key for user=%s", g.user)
+    return make_response(json.dumps({"ok": True}), 200, {"Content-Type": "application/json"})
 
-    token = session.get(SESSION_GALAXY_TOKEN)
-    if not token:
-        return make_response(json.dumps({"error": "No Galaxy session token. Please log out and log back in."}), 401)
 
+# Galaxy Australia — proxy GET /api/histories using the stored API key.
+def galaxy_histories():
+    log.info("galaxy_histories: called, g.user=%s", g.user)
+    if not g.user:
+        log.warning("galaxy_histories: unauthenticated request — returning 403")
+        return make_response(json.dumps({"error": "Not authenticated"}), 403)
+    session_key = session.get(SESSION_GALAXY_API_KEY)
+    fallback_key = _galaxy_fallback_key()
+    api_key = session_key or fallback_key
+    log.info("galaxy_histories: session_key=%s fallback=%s using_key_len=%d",
+             bool(session_key), bool(fallback_key), len(api_key) if api_key else 0)
+    if not api_key:
+        log.warning("galaxy_histories: no API key available — returning 401")
+        return make_response(json.dumps({"error": "no_api_key"}), 401, {"Content-Type": "application/json"})
+    galaxy_url = _galaxy_url()
+    log.info("galaxy_histories: proxying to %s/api/histories", galaxy_url)
     try:
         resp = http_requests.get(
-            f"{GALAXY_AU_URL}/api/histories",
-            headers={"Authorization": f"Bearer {token}"},
-            params={"limit": 200, "order": "update_time-dsc", "view": "summary"},
+            f"{galaxy_url}/api/histories",
+            headers={"x-api-key": api_key},
+            params={"limit": 100, "order": "update_time-dsc", "view": "summary"},
             timeout=15,
         )
+        log.info("galaxy_histories: Galaxy responded %d, body_len=%d", resp.status_code, len(resp.text))
     except http_requests.RequestException as e:
-        log.error("Galaxy histories proxy error: %s", e)
+        log.error("galaxy_histories: request to Galaxy failed: %s", e)
         return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502)
-
     return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
 
 
-# Galaxy Australia proxy: send a resource to a chosen history
+# Galaxy Australia — get presigned S3 URL then proxy a URL-fetch upload to Galaxy.
 def galaxy_send():
+    log.info("galaxy_send: called, g.user=%s", g.user)
     if not g.user:
+        log.warning("galaxy_send: unauthenticated request — returning 403")
         return make_response(json.dumps({"error": "Not authenticated"}), 403)
-
-    token = session.get(SESSION_GALAXY_TOKEN)
-    if not token:
-        return make_response(json.dumps({"error": "No Galaxy session token. Please log out and log back in."}), 401)
+    session_key = session.get(SESSION_GALAXY_API_KEY)
+    fallback_key = _galaxy_fallback_key()
+    api_key = session_key or fallback_key
+    log.info("galaxy_send: session_key=%s fallback=%s", bool(session_key), bool(fallback_key))
+    if not api_key:
+        log.warning("galaxy_send: no API key available — returning 401")
+        return make_response(json.dumps({"error": "no_api_key"}), 401, {"Content-Type": "application/json"})
 
     body = flask_request.get_json(silent=True) or {}
     history_id = body.get("history_id")
     package_id = body.get("package_id")
     resource_id = body.get("resource_id")
-
+    log.info("galaxy_send: history_id=%s package_id=%s resource_id=%s", history_id, package_id, resource_id)
     if not history_id or not package_id or not resource_id:
-        return make_response(json.dumps({"error": "Missing history_id, package_id, or resource_id."}), 400)
+        return make_response(json.dumps({"error": "Missing history_id, package_id or resource_id."}), 400)
 
-    # Get a presigned download URL via s3filestore
     try:
         ctx = {"user": g.user, "auth_user_obj": g.userobj}
         download_info = logic.get_action("download_window")(ctx, {"package_id": package_id, "resource_id": resource_id})
+        log.info("galaxy_send: download_window returned keys=%s", list(download_info.keys()))
     except Exception as e:
-        log.error("download_window error for %s/%s: %s", package_id, resource_id, e)
+        log.error("galaxy_send: download_window error for %s/%s: %s", package_id, resource_id, e)
         return make_response(json.dumps({"error": f"Could not generate download URL: {e}"}), 500)
 
     download_url = download_info.get("url")
+    log.info("galaxy_send: download_url present=%s", bool(download_url))
     if not download_url:
         return make_response(json.dumps({"error": "No download URL available for this resource."}), 404)
 
-    filename = download_info.get("filename") or resource_id
-
-    # Submit the URL-fetch upload job to Galaxy
+    galaxy_url = _galaxy_url()
+    log.info("galaxy_send: posting to %s/api/tools", galaxy_url)
     try:
         resp = http_requests.post(
-            f"{GALAXY_AU_URL}/api/tools",
-            headers={"Authorization": f"Bearer {token}"},
+            f"{galaxy_url}/api/tools",
+            headers={"x-api-key": api_key},
             data={
                 "history_id": history_id,
                 "tool_id": "upload1",
@@ -179,15 +217,15 @@ def galaxy_send():
                     "dbkey": "?",
                     "files_0|type": "upload_dataset",
                     "files_0|url_paste": download_url,
-                    "files_0|NAME": filename,
+                    "files_0|NAME": download_info.get("filename") or resource_id,
                 }),
             },
             timeout=30,
         )
+        log.info("galaxy_send: Galaxy responded %d", resp.status_code)
     except http_requests.RequestException as e:
-        log.error("Galaxy send proxy error: %s", e)
+        log.error("galaxy_send: request to Galaxy failed: %s", e)
         return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502)
-
     return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
 
 
@@ -201,6 +239,7 @@ bpatheme.add_url_rule("/after_login", view_func=route_after_login)
 bpatheme.add_url_rule("/external_styles.css", view_func=external_styles_index)
 # Cart
 bpatheme.add_url_rule("/cart/<target_user>", endpoint="cart", view_func=cart_index)
-# Galaxy Australia proxy
-bpatheme.add_url_rule("/api/galaxy/histories", endpoint="galaxy_histories", view_func=galaxy_histories, methods=["GET"])
-bpatheme.add_url_rule("/api/galaxy/send", endpoint="galaxy_send", view_func=galaxy_send, methods=["POST"])
+# Galaxy Australia
+bpatheme.add_url_rule("/galaxy/set-api-key", endpoint="galaxy_set_api_key", view_func=galaxy_set_api_key, methods=["POST"])
+bpatheme.add_url_rule("/galaxy/histories", endpoint="galaxy_histories", view_func=galaxy_histories, methods=["GET"])
+bpatheme.add_url_rule("/galaxy/send", endpoint="galaxy_send", view_func=galaxy_send, methods=["POST"])

--- a/ckanext/bpatheme/blueprint.py
+++ b/ckanext/bpatheme/blueprint.py
@@ -19,7 +19,8 @@ from ckan.plugins.toolkit import (
     abort,
 )
 
-SESSION_GALAXY_API_KEY = "ckanext:bpa:galaxy_api_key"
+# Stored by ckanext-oidc-pkce-bpa after Auth0 login
+SESSION_GALAXY_ACCESS_TOKEN = "ckanext:bpa:galaxy_access_token"
 
 
 def _galaxy_url():
@@ -27,9 +28,15 @@ def _galaxy_url():
             os.environ.get("GALAXY_AU_URL", "https://usegalaxy.org.au")).rstrip("/")
 
 
-def _galaxy_fallback_key():
-    return (config.get("ckanext.bpatheme.galaxy_api_key") or
-            os.environ.get("GALAXY_API_KEY", ""))
+def _galaxy_auth_headers():
+    """Return Bearer auth headers using the Auth0 access token from the OIDC session.
+
+    Returns ({}, "none") if no token is present — callers must return a 401 in that case.
+    """
+    token = session.get(SESSION_GALAXY_ACCESS_TOKEN)
+    if token:
+        return {"Authorization": f"Bearer {token}"}, "bearer"
+    return {}, "none"
 
 log = getLogger(__name__)
 
@@ -121,50 +128,40 @@ def cart_index(target_user):
     return render("shopping_cart/cart.html",extra_vars={ "user_dict": user_dict })
 
 
-# Galaxy Australia — store the user's Galaxy API key in their CKAN session.
-def galaxy_set_api_key():
-    log.info("galaxy_set_api_key: called, g.user=%s", g.user)
-    if not g.user:
-        log.warning("galaxy_set_api_key: unauthenticated request")
-        return make_response(json.dumps({"error": "Not authenticated"}), 403)
-    body = flask_request.get_json(silent=True) or {}
-    api_key = (body.get("api_key") or "").strip()
-    if api_key:
-        session[SESSION_GALAXY_API_KEY] = api_key
-        log.info("galaxy_set_api_key: stored key for user=%s (len=%d)", g.user, len(api_key))
-    else:
-        session.pop(SESSION_GALAXY_API_KEY, None)
-        log.info("galaxy_set_api_key: cleared key for user=%s", g.user)
-    return make_response(json.dumps({"ok": True}), 200, {"Content-Type": "application/json"})
-
-
-# Galaxy Australia — proxy GET /api/histories using the stored API key.
+# Galaxy Australia — proxy GET /api/histories using the Auth0 Bearer token.
 def galaxy_histories():
     log.info("galaxy_histories: called, g.user=%s", g.user)
     if not g.user:
         log.warning("galaxy_histories: unauthenticated request — returning 403")
         return make_response(json.dumps({"error": "Not authenticated"}), 403)
-    session_key = session.get(SESSION_GALAXY_API_KEY)
-    fallback_key = _galaxy_fallback_key()
-    api_key = session_key or fallback_key
-    log.info("galaxy_histories: session_key=%s fallback=%s using_key_len=%d",
-             bool(session_key), bool(fallback_key), len(api_key) if api_key else 0)
-    if not api_key:
-        log.warning("galaxy_histories: no API key available — returning 401")
-        return make_response(json.dumps({"error": "no_api_key"}), 401, {"Content-Type": "application/json"})
+    auth_headers, auth_method = _galaxy_auth_headers()
+    log.info("galaxy_histories: auth_method=%s has_headers=%s", auth_method, bool(auth_headers))
+    if not auth_headers:
+        log.warning("galaxy_histories: no OIDC token in session")
+        return make_response(json.dumps({"error": "No authentication token available. Please log out and log in again."}), 400, {"Content-Type": "application/json"})
     galaxy_url = _galaxy_url()
     log.info("galaxy_histories: proxying to %s/api/histories", galaxy_url)
     try:
         resp = http_requests.get(
             f"{galaxy_url}/api/histories",
-            headers={"x-api-key": api_key},
+            headers=auth_headers,
             params={"limit": 100, "order": "update_time-dsc", "view": "summary"},
             timeout=15,
         )
-        log.info("galaxy_histories: Galaxy responded %d, body_len=%d", resp.status_code, len(resp.text))
+        log.info("galaxy_histories: Galaxy responded %d", resp.status_code)
     except http_requests.RequestException as e:
         log.error("galaxy_histories: request to Galaxy failed: %s", e)
-        return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502)
+        return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
+    # Translate Galaxy 4xx to 502 — returning 401/403 triggers repoze.who login redirect
+    if resp.status_code in (401, 403):
+        msg = "Your login session was not accepted by Galaxy Australia. Please log into Galaxy Australia once using the BioCommons login button to link your account."
+        try:
+            body = resp.json()
+            if body.get("err_msg"):
+                log.warning("galaxy_histories: Galaxy auth error: %s", body["err_msg"])
+        except Exception:
+            pass
+        return make_response(json.dumps({"error": msg}), 502, {"Content-Type": "application/json"})
     return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
 
 
@@ -174,58 +171,99 @@ def galaxy_send():
     if not g.user:
         log.warning("galaxy_send: unauthenticated request — returning 403")
         return make_response(json.dumps({"error": "Not authenticated"}), 403)
-    session_key = session.get(SESSION_GALAXY_API_KEY)
-    fallback_key = _galaxy_fallback_key()
-    api_key = session_key or fallback_key
-    log.info("galaxy_send: session_key=%s fallback=%s", bool(session_key), bool(fallback_key))
-    if not api_key:
-        log.warning("galaxy_send: no API key available — returning 401")
-        return make_response(json.dumps({"error": "no_api_key"}), 401, {"Content-Type": "application/json"})
+    auth_headers, auth_method = _galaxy_auth_headers()
+    log.info("galaxy_send: auth_method=%s has_headers=%s", auth_method, bool(auth_headers))
+    if not auth_headers:
+        log.warning("galaxy_send: no OIDC token in session")
+        return make_response(json.dumps({"error": "No authentication token available. Please log out and log in again."}), 400, {"Content-Type": "application/json"})
 
     body = flask_request.get_json(silent=True) or {}
     history_id = body.get("history_id")
     package_id = body.get("package_id")
     resource_id = body.get("resource_id")
-    log.info("galaxy_send: history_id=%s package_id=%s resource_id=%s", history_id, package_id, resource_id)
+    resource_name = body.get("resource_name") or resource_id
+    log.info("galaxy_send: history_id=%s resource_id=%s", history_id, resource_id)
     if not history_id or not package_id or not resource_id:
         return make_response(json.dumps({"error": "Missing history_id, package_id or resource_id."}), 400)
 
-    try:
-        ctx = {"user": g.user, "auth_user_obj": g.userobj}
-        download_info = logic.get_action("download_window")(ctx, {"package_id": package_id, "resource_id": resource_id})
-        log.info("galaxy_send: download_window returned keys=%s", list(download_info.keys()))
-    except Exception as e:
-        log.error("galaxy_send: download_window error for %s/%s: %s", package_id, resource_id, e)
-        return make_response(json.dumps({"error": f"Could not generate download URL: {e}"}), 500)
-
-    download_url = download_info.get("url")
-    log.info("galaxy_send: download_url present=%s", bool(download_url))
-    if not download_url:
-        return make_response(json.dumps({"error": "No download URL available for this resource."}), 404)
+    from urllib.parse import urlparse as _urlparse
+    hostname = _urlparse(config.get("ckan.site_url", "")).hostname or ""
+    drs_uri = f"drs://{hostname}/{resource_id}"
+    log.info("galaxy_send: DRS URI=%s", drs_uri)
 
     galaxy_url = _galaxy_url()
-    log.info("galaxy_send: posting to %s/api/tools", galaxy_url)
+    log.info("galaxy_send: posting to %s/api/tools/fetch", galaxy_url)
     try:
         resp = http_requests.post(
-            f"{galaxy_url}/api/tools",
-            headers={"x-api-key": api_key},
-            data={
+            f"{galaxy_url}/api/tools/fetch",
+            headers=auth_headers,
+            json={
                 "history_id": history_id,
-                "tool_id": "upload1",
-                "inputs": json.dumps({
-                    "file_type": "auto",
-                    "dbkey": "?",
-                    "files_0|type": "upload_dataset",
-                    "files_0|url_paste": download_url,
-                    "files_0|NAME": download_info.get("filename") or resource_id,
-                }),
+                "targets": [{
+                    "destination": {"type": "hdas"},
+                    "elements": [{
+                        "src": "url",
+                        "url": drs_uri,
+                        "name": resource_name,
+                    }]
+                }]
             },
             timeout=30,
         )
         log.info("galaxy_send: Galaxy responded %d", resp.status_code)
     except http_requests.RequestException as e:
         log.error("galaxy_send: request to Galaxy failed: %s", e)
-        return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502)
+        return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
+    if resp.status_code in (401, 403):
+        return make_response(json.dumps({"error": "Your login session was not accepted by Galaxy Australia. Please log into Galaxy Australia once using the BioCommons login button to link your account."}), 502, {"Content-Type": "application/json"})
+    return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
+
+
+# Galaxy Australia — send entire package as a DRS bundle to Galaxy.
+def galaxy_send_bundle():
+    log.info("galaxy_send_bundle: called, g.user=%s", g.user)
+    if not g.user:
+        return make_response(json.dumps({"error": "Not authenticated"}), 403)
+    auth_headers, auth_method = _galaxy_auth_headers()
+    if not auth_headers:
+        return make_response(json.dumps({"error": "No authentication token available. Please log out and log in again."}), 400, {"Content-Type": "application/json"})
+
+    body = flask_request.get_json(silent=True) or {}
+    history_id = body.get("history_id")
+    package_id = body.get("package_id")
+    log.info("galaxy_send_bundle: history_id=%s package_id=%s", history_id, package_id)
+    if not history_id or not package_id:
+        return make_response(json.dumps({"error": "Missing history_id or package_id."}), 400)
+
+    from urllib.parse import urlparse as _urlparse
+    hostname = _urlparse(config.get("ckan.site_url", "")).hostname or ""
+    drs_bundle_uri = f"drs://{hostname}/~{package_id}"
+    log.info("galaxy_send_bundle: DRS bundle URI=%s", drs_bundle_uri)
+
+    galaxy_url = _galaxy_url()
+    try:
+        resp = http_requests.post(
+            f"{galaxy_url}/api/tools/fetch",
+            headers=auth_headers,
+            json={
+                "history_id": history_id,
+                "targets": [{
+                    "destination": {"type": "hdas"},
+                    "elements": [{
+                        "src": "url",
+                        "url": drs_bundle_uri,
+                        "name": package_id,
+                    }]
+                }]
+            },
+            timeout=30,
+        )
+        log.info("galaxy_send_bundle: Galaxy responded %d", resp.status_code)
+    except http_requests.RequestException as e:
+        log.error("galaxy_send_bundle: request to Galaxy failed: %s", e)
+        return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
+    if resp.status_code in (401, 403):
+        return make_response(json.dumps({"error": "Your login session was not accepted by Galaxy Australia. Please log into Galaxy Australia once using the BioCommons login button to link your account."}), 502, {"Content-Type": "application/json"})
     return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
 
 
@@ -240,6 +278,6 @@ bpatheme.add_url_rule("/external_styles.css", view_func=external_styles_index)
 # Cart
 bpatheme.add_url_rule("/cart/<target_user>", endpoint="cart", view_func=cart_index)
 # Galaxy Australia
-bpatheme.add_url_rule("/galaxy/set-api-key", endpoint="galaxy_set_api_key", view_func=galaxy_set_api_key, methods=["POST"])
 bpatheme.add_url_rule("/galaxy/histories", endpoint="galaxy_histories", view_func=galaxy_histories, methods=["GET"])
 bpatheme.add_url_rule("/galaxy/send", endpoint="galaxy_send", view_func=galaxy_send, methods=["POST"])
+bpatheme.add_url_rule("/galaxy/send-bundle", endpoint="galaxy_send_bundle", view_func=galaxy_send_bundle, methods=["POST"])

--- a/ckanext/bpatheme/blueprint.py
+++ b/ckanext/bpatheme/blueprint.py
@@ -1,15 +1,16 @@
 # encoding: utf-8
 
-from flask import Blueprint, make_response
+from flask import Blueprint, make_response, request as flask_request
 
 import json
 import os
 import time
 import hmac
 import hashlib
+import requests as http_requests
 from logging import getLogger
 
-from ckan.common import g
+from ckan.common import g, session
 import ckan.lib.base as base
 import ckan.lib.helpers as h
 import ckan.logic as logic
@@ -17,6 +18,9 @@ from ckan.plugins.toolkit import (
     render,
     abort,
 )
+
+GALAXY_AU_URL = os.environ.get("GALAXY_AU_URL", "https://usegalaxy.org.au")
+SESSION_GALAXY_TOKEN = "ckanext:bpa:galaxy_access_token"
 
 log = getLogger(__name__)
 
@@ -108,6 +112,85 @@ def cart_index(target_user):
     return render("shopping_cart/cart.html",extra_vars={ "user_dict": user_dict })
 
 
+# Galaxy Australia proxy: list user's histories
+def galaxy_histories():
+    if not g.user:
+        return make_response(json.dumps({"error": "Not authenticated"}), 403)
+
+    token = session.get(SESSION_GALAXY_TOKEN)
+    if not token:
+        return make_response(json.dumps({"error": "No Galaxy session token. Please log out and log back in."}), 401)
+
+    try:
+        resp = http_requests.get(
+            f"{GALAXY_AU_URL}/api/histories",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"limit": 200, "order": "update_time-dsc", "view": "summary"},
+            timeout=15,
+        )
+    except http_requests.RequestException as e:
+        log.error("Galaxy histories proxy error: %s", e)
+        return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502)
+
+    return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
+
+
+# Galaxy Australia proxy: send a resource to a chosen history
+def galaxy_send():
+    if not g.user:
+        return make_response(json.dumps({"error": "Not authenticated"}), 403)
+
+    token = session.get(SESSION_GALAXY_TOKEN)
+    if not token:
+        return make_response(json.dumps({"error": "No Galaxy session token. Please log out and log back in."}), 401)
+
+    body = flask_request.get_json(silent=True) or {}
+    history_id = body.get("history_id")
+    package_id = body.get("package_id")
+    resource_id = body.get("resource_id")
+
+    if not history_id or not package_id or not resource_id:
+        return make_response(json.dumps({"error": "Missing history_id, package_id, or resource_id."}), 400)
+
+    # Get a presigned download URL via s3filestore
+    try:
+        ctx = {"user": g.user, "auth_user_obj": g.userobj}
+        download_info = logic.get_action("download_window")(ctx, {"package_id": package_id, "resource_id": resource_id})
+    except Exception as e:
+        log.error("download_window error for %s/%s: %s", package_id, resource_id, e)
+        return make_response(json.dumps({"error": f"Could not generate download URL: {e}"}), 500)
+
+    download_url = download_info.get("url")
+    if not download_url:
+        return make_response(json.dumps({"error": "No download URL available for this resource."}), 404)
+
+    filename = download_info.get("filename") or resource_id
+
+    # Submit the URL-fetch upload job to Galaxy
+    try:
+        resp = http_requests.post(
+            f"{GALAXY_AU_URL}/api/tools",
+            headers={"Authorization": f"Bearer {token}"},
+            data={
+                "history_id": history_id,
+                "tool_id": "upload1",
+                "inputs": json.dumps({
+                    "file_type": "auto",
+                    "dbkey": "?",
+                    "files_0|type": "upload_dataset",
+                    "files_0|url_paste": download_url,
+                    "files_0|NAME": filename,
+                }),
+            },
+            timeout=30,
+        )
+    except http_requests.RequestException as e:
+        log.error("Galaxy send proxy error: %s", e)
+        return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502)
+
+    return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
+
+
 bpatheme.add_url_rule("/summary", view_func=summary_index)
 bpatheme.add_url_rule("/contact", view_func=contact_index)
 bpatheme.add_url_rule("/all_projects", view_func=all_projects_index)
@@ -118,3 +201,6 @@ bpatheme.add_url_rule("/after_login", view_func=route_after_login)
 bpatheme.add_url_rule("/external_styles.css", view_func=external_styles_index)
 # Cart
 bpatheme.add_url_rule("/cart/<target_user>", endpoint="cart", view_func=cart_index)
+# Galaxy Australia proxy
+bpatheme.add_url_rule("/api/galaxy/histories", endpoint="galaxy_histories", view_func=galaxy_histories, methods=["GET"])
+bpatheme.add_url_rule("/api/galaxy/send", endpoint="galaxy_send", view_func=galaxy_send, methods=["POST"])

--- a/ckanext/bpatheme/helper.py
+++ b/ckanext/bpatheme/helper.py
@@ -947,6 +947,9 @@ def galaxy_enabled():
 
     # list not empty
     if enabled_orgs:
+        # set false unless we find a enabled organisation
+        galaxy_enabled = False
+        
         all_organizations = toolkit.get_action("organization_list")(
             data_dict={
                 "all_fields": True,

--- a/ckanext/bpatheme/helper.py
+++ b/ckanext/bpatheme/helper.py
@@ -932,3 +932,32 @@ def get_galaxy_url():
         config.get("ckanext.bpatheme.galaxy_url")
         or os.environ.get("GALAXY_AU_URL", "https://usegalaxy.org.au")
     ).rstrip("/")
+
+
+def galaxy_enabled():
+    """Feature flag to enable/disable Galaxy transfer features"""
+
+    galaxy_enabled = config.get("ckanext.bpatheme.enable_galaxy", False)
+
+    # Convert the value from a string to a boolean.
+    galaxy_enabled = toolkit.asbool(galaxy_enabled)
+
+    # if we've got a list of organisations defined in ckanext.bpatheme.galaxy_enabled_orgs, honour that
+    enabled_orgs = config.get("ckanext.bpatheme.galaxy_enabled_orgs").split()
+
+    # list not empty
+    if enabled_orgs:
+        all_organizations = toolkit.get_action("organization_list")(
+            data_dict={
+                "all_fields": True,
+                "include_extras": False,
+                "include_dataset_count": False,
+                "include_groups": False,
+                }
+            )
+
+        for org in all_organizations:
+            if org["name"] in enabled_orgs:
+                galaxy_enabled = True
+
+    return galaxy_enabled

--- a/ckanext/bpatheme/helper.py
+++ b/ckanext/bpatheme/helper.py
@@ -914,3 +914,21 @@ def render_ncbi_bioproject_url(ncbi_bioproject_accession):
         return ""
 
     return "https://www.ncbi.nlm.nih.gov/bioproject/%s/" % (ncbi_bioproject_accession,)
+
+
+def get_drs_uri(object_id):
+    """Return a DRS URI for a resource or package bundle.
+
+    Resources:  drs://<host>/<resource_id>
+    Packages:   drs://<host>/~<package_id>  (caller must pass id prefixed with ~)
+    """
+    hostname = urlparse(config.get("ckan.site_url", "")).hostname or ""
+    return "drs://{}/{}".format(hostname, object_id)
+
+
+def get_galaxy_url():
+    """Return the Galaxy Australia instance URL, configurable via ckan.ini or env var."""
+    return (
+        config.get("ckanext.bpatheme.galaxy_url")
+        or os.environ.get("GALAXY_AU_URL", "https://usegalaxy.org.au")
+    ).rstrip("/")

--- a/ckanext/bpatheme/plugins.py
+++ b/ckanext/bpatheme/plugins.py
@@ -145,6 +145,7 @@ class CustomTheme(plugins.SingletonPlugin):
             "render_ncbi_bioproject_url": helper.render_ncbi_bioproject_url,
             "get_drs_uri": helper.get_drs_uri,
             "get_galaxy_url": helper.get_galaxy_url,
+            "galaxy_enabled": helper.galaxy_enabled,
         }
 
     # Ifacets

--- a/ckanext/bpatheme/plugins.py
+++ b/ckanext/bpatheme/plugins.py
@@ -143,6 +143,8 @@ class CustomTheme(plugins.SingletonPlugin):
             "check_user_dataset_access":helper.check_user_dataset_access,
             "is_bioproject": helper.is_bioproject,
             "render_ncbi_bioproject_url": helper.render_ncbi_bioproject_url,
+            "get_drs_uri": helper.get_drs_uri,
+            "get_galaxy_url": helper.get_galaxy_url,
         }
 
     # Ifacets

--- a/ckanext/bpatheme/templates/ckanext_bulk/ajax_snippets/bulk_download_popover.html
+++ b/ckanext/bpatheme/templates/ckanext_bulk/ajax_snippets/bulk_download_popover.html
@@ -1,0 +1,16 @@
+{% ckan_extends %}
+
+{% block bulk_download_popover_additions %}
+      {% asset 'ckanext-bpatheme/galaxy-send-js' %}
+      {% if h.galaxy_enabled() %}
+        {% if package_id and g.user %}
+        <a href="#"
+           class="btn btn-default"
+           data-module="galaxy_send"
+           data-module-package-id="{{ package_id }}"
+           data-module-galaxy-url="{{ h.get_galaxy_url() }}">
+            <i class="fa fa-rocket"></i>{{ _(' Send to Galaxy Australia') }}
+        </a>
+        {% endif %}
+      {% endif %}
+{% endblock %}

--- a/ckanext/bpatheme/templates/package/resource_read.html
+++ b/ckanext/bpatheme/templates/package/resource_read.html
@@ -36,19 +36,21 @@
                             resource_id=res.id
                             %}
                         </li>
-                        {% if g.user %}
-                        <li>
-                            {% asset 'ckanext-bpatheme/galaxy-send-js' %}
-                            <a href="#"
-                               data-module="galaxy_send"
-                               data-module-resource-id="{{ res.id }}"
-                               data-module-package-id="{{ pkg.name }}"
-                               data-module-resource-name="{{ h.resource_display_name(res) | e }}"
-                               data-module-galaxy-url="{{ h.get_galaxy_url() }}">
-                                <i class="fa fa-rocket"></i>
-                                {{ _('Send to Galaxy Australia') }}
-                            </a>
-                        </li>
+                        {% if h.galaxy_enabled() %}
+                          {% asset 'ckanext-bpatheme/galaxy-send-js' %}
+                          {% if g.user %}
+                          <li>
+                              <a href="#"
+                                 data-module="galaxy_send"
+                                 data-module-resource-id="{{ res.id }}"
+                                 data-module-package-id="{{ pkg.name }}"
+                                 data-module-resource-name="{{ h.resource_display_name(res) | e }}"
+                                 data-module-galaxy-url="{{ h.get_galaxy_url() }}">
+                                  <i class="fa fa-rocket"></i>
+                                  {{ _('Send to Galaxy Australia') }}
+                              </a>
+                          </li>
+                          {% endif %}
                         {% endif %}
                         {% endif %}
             {% if res.url and h.is_url(res.url) %}

--- a/ckanext/bpatheme/templates/package/resource_read.html
+++ b/ckanext/bpatheme/templates/package/resource_read.html
@@ -43,7 +43,8 @@
                                data-module="galaxy_send"
                                data-module-resource-id="{{ res.id }}"
                                data-module-package-id="{{ pkg.name }}"
-                               data-module-resource-name="{{ h.resource_display_name(res) | e }}">
+                               data-module-resource-name="{{ h.resource_display_name(res) | e }}"
+                               data-module-galaxy-url="{{ h.get_galaxy_url() }}">
                                 <i class="fa fa-rocket"></i>
                                 {{ _('Send to Galaxy Australia') }}
                             </a>

--- a/ckanext/bpatheme/templates/package/resource_read.html
+++ b/ckanext/bpatheme/templates/package/resource_read.html
@@ -36,6 +36,19 @@
                             resource_id=res.id
                             %}
                         </li>
+                        {% if g.user %}
+                        <li>
+                            {% asset 'ckanext-bpatheme/galaxy-send-js' %}
+                            <a href="#"
+                               data-module="galaxy_send"
+                               data-module-resource-id="{{ res.id }}"
+                               data-module-package-id="{{ pkg.name }}"
+                               data-module-resource-name="{{ h.resource_display_name(res) | e }}">
+                                <i class="fa fa-rocket"></i>
+                                {{ _('Send to Galaxy Australia') }}
+                            </a>
+                        </li>
+                        {% endif %}
                         {% endif %}
             {% if res.url and h.is_url(res.url) %}
               <li>

--- a/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
+++ b/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
@@ -42,19 +42,21 @@
                             {% snippet 'ckanext_s3filestore/snippets/download_window_link.html', id=pkg.name, resource_id=res.id %}
                         </li>
                         {% endif %}
-                        {% if g.user %}
-                        <li>
-                            {% asset 'ckanext-bpatheme/galaxy-send-js' %}
-                            <a href="#"
-                               data-module="galaxy_send"
-                               data-module-resource-id="{{ res.id }}"
-                               data-module-package-id="{{ pkg.name }}"
-                               data-module-resource-name="{{ h.resource_display_name(res) | e }}"
-                               data-module-galaxy-url="{{ h.get_galaxy_url() }}">
-                                <i class="fa fa-rocket"></i>
-                                {{ _('Send to Galaxy Australia') }}
-                            </a>
-                        </li>
+                        {% if h.galaxy_enabled() %}
+                          {% asset 'ckanext-bpatheme/galaxy-send-js' %}
+                          {% if g.user %}
+                          <li>
+                              <a href="#"
+                                 data-module="galaxy_send"
+                                 data-module-resource-id="{{ res.id }}"
+                                 data-module-package-id="{{ pkg.name }}"
+                                 data-module-resource-name="{{ h.resource_display_name(res) | e }}"
+                                 data-module-galaxy-url="{{ h.get_galaxy_url() }}">
+                                  <i class="fa fa-rocket"></i>
+                                  {{ _('Send to Galaxy Australia') }}
+                              </a>
+                          </li>
+                          {% endif %}
                         {% endif %}
                         {% if can_edit %}
                         <li>

--- a/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
+++ b/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
@@ -42,6 +42,19 @@
                             {% snippet 'ckanext_s3filestore/snippets/download_window_link.html', id=pkg.name, resource_id=res.id %}
                         </li>
                         {% endif %}
+                        {% if g.user %}
+                        <li>
+                            {% asset 'ckanext-bpatheme/galaxy-send-js' %}
+                            <a href="#"
+                               data-module="galaxy_send"
+                               data-module-resource-id="{{ res.id }}"
+                               data-module-package-id="{{ pkg.name }}"
+                               data-module-resource-name="{{ h.resource_display_name(res) | e }}">
+                                <i class="fa fa-rocket"></i>
+                                {{ _('Send to Galaxy Australia') }}
+                            </a>
+                        </li>
+                        {% endif %}
                         {% if can_edit %}
                         <li>
                             <a href="{{ h.url_for(pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id) }}">

--- a/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
+++ b/ckanext/bpatheme/templates/package/snippets/resource_item/auth_explore.html
@@ -49,7 +49,8 @@
                                data-module="galaxy_send"
                                data-module-resource-id="{{ res.id }}"
                                data-module-package-id="{{ pkg.name }}"
-                               data-module-resource-name="{{ h.resource_display_name(res) | e }}">
+                               data-module-resource-name="{{ h.resource_display_name(res) | e }}"
+                               data-module-galaxy-url="{{ h.get_galaxy_url() }}">
                                 <i class="fa fa-rocket"></i>
                                 {{ _('Send to Galaxy Australia') }}
                             </a>


### PR DESCRIPTION
## Changes

- Adds a **Send to Galaxy Australia** button to the resource Access dropdown (individual resources) and to the bulk download popover (entire dataset bundle)
- Authenticates to Galaxy using the user's existing Auth0/OIDC session — no separate Galaxy API key required
- Uses DRS URIs for data transfer: individual resources use `drs://<host>/<resource_id>`, bundles use `drs://<host>/~<package_id>`
- Server-side Flask proxy handles all Galaxy API calls to avoid CORS issues and keep credentials off the client

## Changes

| File | Purpose |
|---|---|
| `blueprint.py` | Three new routes: `GET /galaxy/histories`, `POST /galaxy/send`, `POST /galaxy/send-bundle` |
| `galaxy_send.js` | CKAN module powering the modal — history list, single-resource send, and bundle send |
| `drs_copy_uri.js` | CKAN module for copying DRS URIs to clipboard |
| `webassets.yml` | Registers `galaxy-send-js` and `drs-copy-js` assets |
| `helper.py` | `get_drs_uri()` and `get_galaxy_url()` helpers |
| `plugins.py` | Registers the new helpers |
| `resource_read.html` | Send to Galaxy button in single-resource Access dropdown |
| `auth_explore.html` | Send to Galaxy button in resource list Access dropdown |

## Auth flow

1. User logs in to CKAN via Auth0 — the OIDC plugin stores the access token in the Flask session
2. CKAN proxy forwards `Authorization: Bearer <token>` to Galaxy's API
3. Galaxy validates the JWT via Auth0's JWKS and maps to the Galaxy user (requires the user to have logged into Galaxy once with BioCommons login)

## Related Pull Requests
- https://github.com/BioplatformsAustralia/ckanext-oidc-pkce-bpa/pull/23
- https://github.com/BioplatformsAustralia/ckanext-bulk/pull/12
- https://github.com/BioplatformsAustralia/docker-bpa-ckan/pull/21
- https://github.com/BioplatformsAustralia/dockercompose-bpa-ckan/pull/10
- https://github.com/BioplatformsAustralia/ckanext-drs/pull/3

## Screen Recording
You will see a sample of data transfer for individual resources and bundled resources

https://github.com/user-attachments/assets/b2155e76-e4de-48c1-ac4f-64edafec623b

