### PR TITLE
fix: enable single file in history dataset

### DIFF
--- a/ckanext/bpatheme/blueprint.py
+++ b/ckanext/bpatheme/blueprint.py
@@ -336,9 +336,7 @@ def galaxy_send_bundle():
             json={
                 "history_id": history_id,
                 "targets": [{
-                    "destination": {"type": "hdca"},
-                    "collection_type": "list",
-                    "name": collection_name,
+                    "destination": {"type": "hdas"},
                     "elements": elements,
                 }]
             },


### PR DESCRIPTION
Switched to `hdas` and dropped `collection_type` and `name` from the target. 

The bundle is already expanded server-side into individual elements, so Galaxy will import each file as a separate history dataset.