### PR TITLE
fix: add more intuitive messaging to users when data transfer

### DIFF
--- a/ckanext/bpatheme/assets/scripts/galaxy_send.js
+++ b/ckanext/bpatheme/assets/scripts/galaxy_send.js
@@ -260,15 +260,9 @@ ckan.module('galaxy_send', function ($) {
                     sendBtn.prop('disabled', false).html('<i class="fa fa-rocket"></i> Send to Galaxy');
                     var msg = 'Failed to send to Galaxy Australia.';
                     try { var b = JSON.parse(xhr.responseText); if (b && b.error) { msg = b.error; } } catch (ignored) {}
-                    if (xhr.status === 401 || xhr.status === 403) {
-                        msg = 'To proceed with the data transfer, please log into Galaxy Australia, then return here and try again.';
-                    }
-                    var hint = '';
-                    if (msg.indexOf('expired') !== -1) {
-                        hint = ' If this error appears again, please retry the data transfer — Galaxy Australia will refresh your session automatically.';
-                    }
+
                     modal.find('#galaxy-modal-error').html(
-                        '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg) + _escHtml(hint)
+                        '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg)
                     ).show();
                 },
             });

--- a/ckanext/bpatheme/assets/scripts/galaxy_send.js
+++ b/ckanext/bpatheme/assets/scripts/galaxy_send.js
@@ -212,7 +212,7 @@ ckan.module('galaxy_send', function ($) {
                 if (b && b.error) { msg = b.error; }
             } catch (ignored) {}
             if (xhr.status === 401 || xhr.status === 403) {
-                msg = 'Authentication failed. Please ensure you are logged in via your institutional account, which must be linked to Galaxy Australia.';
+                msg = 'To proceed with the data transfer, please log into Galaxy Australia once using the BioCommons login button to link your account, then return here and try again.';
             }
             modal.find('#galaxy-modal-error').html(
                 '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg)
@@ -260,8 +260,15 @@ ckan.module('galaxy_send', function ($) {
                     sendBtn.prop('disabled', false).html('<i class="fa fa-rocket"></i> Send to Galaxy');
                     var msg = 'Failed to send to Galaxy Australia.';
                     try { var b = JSON.parse(xhr.responseText); if (b && b.error) { msg = b.error; } } catch (ignored) {}
+                    if (xhr.status === 401 || xhr.status === 403) {
+                        msg = 'To proceed with the data transfer, please log into Galaxy Australia once using the BioCommons login button to link your account, then return here and try again.';
+                    }
+                    var hint = '';
+                    if (msg.indexOf('expired') !== -1) {
+                        hint = ' If this error appears again, please retry — Galaxy will refresh your session automatically.';
+                    }
                     modal.find('#galaxy-modal-error').html(
-                        '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg)
+                        '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg) + _escHtml(hint)
                     ).show();
                 },
             });

--- a/ckanext/bpatheme/assets/scripts/galaxy_send.js
+++ b/ckanext/bpatheme/assets/scripts/galaxy_send.js
@@ -265,7 +265,7 @@ ckan.module('galaxy_send', function ($) {
                     }
                     var hint = '';
                     if (msg.indexOf('expired') !== -1) {
-                        hint = ' If this error appears again, please retry — Galaxy will refresh your session automatically.';
+                        hint = ' If this error appears again, please retry the data transfer — Galaxy Australia will refresh your session automatically.';
                     }
                     modal.find('#galaxy-modal-error').html(
                         '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg) + _escHtml(hint)

--- a/ckanext/bpatheme/assets/scripts/galaxy_send.js
+++ b/ckanext/bpatheme/assets/scripts/galaxy_send.js
@@ -212,7 +212,7 @@ ckan.module('galaxy_send', function ($) {
                 if (b && b.error) { msg = b.error; }
             } catch (ignored) {}
             if (xhr.status === 401 || xhr.status === 403) {
-                msg = 'To proceed with the data transfer, please log into Galaxy Australia once using the BioCommons login button to link your account, then return here and try again.';
+                msg = 'To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again.';
             }
             modal.find('#galaxy-modal-error').html(
                 '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg)
@@ -261,7 +261,7 @@ ckan.module('galaxy_send', function ($) {
                     var msg = 'Failed to send to Galaxy Australia.';
                     try { var b = JSON.parse(xhr.responseText); if (b && b.error) { msg = b.error; } } catch (ignored) {}
                     if (xhr.status === 401 || xhr.status === 403) {
-                        msg = 'To proceed with the data transfer, please log into Galaxy Australia once using the BioCommons login button to link your account, then return here and try again.';
+                        msg = 'To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again.';
                     }
                     var hint = '';
                     if (msg.indexOf('expired') !== -1) {

--- a/ckanext/bpatheme/assets/scripts/galaxy_send.js
+++ b/ckanext/bpatheme/assets/scripts/galaxy_send.js
@@ -212,7 +212,7 @@ ckan.module('galaxy_send', function ($) {
                 if (b && b.error) { msg = b.error; }
             } catch (ignored) {}
             if (xhr.status === 401 || xhr.status === 403) {
-                msg = 'To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again.';
+                msg = 'To proceed with the data transfer, please log into Galaxy Australia, then return here and try again.';
             }
             modal.find('#galaxy-modal-error').html(
                 '<i class="fa fa-exclamation-triangle"></i> ' + _escHtml(msg)
@@ -261,7 +261,7 @@ ckan.module('galaxy_send', function ($) {
                     var msg = 'Failed to send to Galaxy Australia.';
                     try { var b = JSON.parse(xhr.responseText); if (b && b.error) { msg = b.error; } } catch (ignored) {}
                     if (xhr.status === 401 || xhr.status === 403) {
-                        msg = 'To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again.';
+                        msg = 'To proceed with the data transfer, please log into Galaxy Australia, then return here and try again.';
                     }
                     var hint = '';
                     if (msg.indexOf('expired') !== -1) {

--- a/ckanext/bpatheme/blueprint.py
+++ b/ckanext/bpatheme/blueprint.py
@@ -221,7 +221,7 @@ def galaxy_histories():
         return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
     # Translate Galaxy 4xx to 502 — returning 401/403 triggers repoze.who login redirect
     if resp.status_code in (401, 403):
-        msg = "To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again."
+        msg = "To proceed with the data transfer, please log into Galaxy Australia, then return here and try again."
         try:
             body = resp.json()
             if body.get("err_msg"):
@@ -282,7 +282,7 @@ def galaxy_send():
         log.error("galaxy_send: request to Galaxy failed: %s", e)
         return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
     if resp.status_code in (401, 403):
-        return make_response(json.dumps({"error": "To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again."}), 502, {"Content-Type": "application/json"})
+        return make_response(json.dumps({"error": "To proceed with the data transfer, please log into Galaxy Australia, then return here and try again."}), 502, {"Content-Type": "application/json"})
     return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
 
 
@@ -347,7 +347,7 @@ def galaxy_send_bundle():
         log.error("galaxy_send_bundle: request to Galaxy failed: %s", e)
         return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
     if resp.status_code in (401, 403):
-        return make_response(json.dumps({"error": "To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again."}), 502, {"Content-Type": "application/json"})
+        return make_response(json.dumps({"error": "To proceed with the data transfer, please log into Galaxy Australia, then return here and try again."}), 502, {"Content-Type": "application/json"})
     return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
 
 

--- a/ckanext/bpatheme/blueprint.py
+++ b/ckanext/bpatheme/blueprint.py
@@ -221,7 +221,7 @@ def galaxy_histories():
         return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
     # Translate Galaxy 4xx to 502 — returning 401/403 triggers repoze.who login redirect
     if resp.status_code in (401, 403):
-        msg = "Your login session was not accepted by Galaxy Australia. Please log into Galaxy Australia once using the BioCommons login button to link your account."
+        msg = "To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again."
         try:
             body = resp.json()
             if body.get("err_msg"):
@@ -282,7 +282,7 @@ def galaxy_send():
         log.error("galaxy_send: request to Galaxy failed: %s", e)
         return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
     if resp.status_code in (401, 403):
-        return make_response(json.dumps({"error": "Your login session was not accepted by Galaxy Australia. Please log into Galaxy Australia once using the BioCommons login button to link your account."}), 502, {"Content-Type": "application/json"})
+        return make_response(json.dumps({"error": "To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again."}), 502, {"Content-Type": "application/json"})
     return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
 
 
@@ -347,7 +347,7 @@ def galaxy_send_bundle():
         log.error("galaxy_send_bundle: request to Galaxy failed: %s", e)
         return make_response(json.dumps({"error": "Could not reach Galaxy Australia."}), 502, {"Content-Type": "application/json"})
     if resp.status_code in (401, 403):
-        return make_response(json.dumps({"error": "Your login session was not accepted by Galaxy Australia. Please log into Galaxy Australia once using the BioCommons login button to link your account."}), 502, {"Content-Type": "application/json"})
+        return make_response(json.dumps({"error": "To proceed with the data transfer, please log into Galaxy Australia once to link your account, then return here and try again."}), 502, {"Content-Type": "application/json"})
     return make_response(resp.text, resp.status_code, {"Content-Type": "application/json"})
 
 


### PR DESCRIPTION
Improves user-facing error messages for the Galaxy Australia data transfer flow.

- Replace the generic auth failure message with clearer guidance directing users to log into Galaxy Australia first via the BioCommons login button, then return to retry the transfer
